### PR TITLE
support comment editing

### DIFF
--- a/cmd/comments/main.go
+++ b/cmd/comments/main.go
@@ -109,12 +109,17 @@ func main() {
 		pz.Route{
 			Method:  "POST",
 			Path:    "/api/posts/{post-id}/comments",
-			Handler: a.AuthN(apiAuth, commentsService.PutComment),
+			Handler: a.AuthN(apiAuth, commentsService.Put),
 		},
 		pz.Route{
 			Method:  "GET",
 			Path:    "/api/posts/{post-id}/comments/{comment-id}",
-			Handler: commentsService.GetComment,
+			Handler: commentsService.Get,
+		},
+		pz.Route{
+			Method:  "PATCH",
+			Path:    "/api/posts/{post-id}/comments/{comment-id}",
+			Handler: a.AuthN(apiAuth, commentsService.Update),
 		},
 		pz.Route{
 			Method:  "GET",
@@ -140,6 +145,16 @@ func main() {
 			Method:  "POST",
 			Path:    "/posts/{post-id}/comments/{comment-id}/reply",
 			Handler: a.AuthN(&webServerAuth, webServer.Reply),
+		},
+		pz.Route{
+			Method:  "GET",
+			Path:    "/posts/{post-id}/comments/{comment-id}/edit",
+			Handler: a.AuthN(&webServerAuth, webServer.EditForm),
+		},
+		pz.Route{
+			Method:  "POST",
+			Path:    "/posts/{post-id}/comments/{comment-id}/edit",
+			Handler: a.AuthN(&webServerAuth, webServer.Edit),
 		},
 	)); err != nil {
 		log.Fatal(err)

--- a/pkg/comments/commentsservice.go
+++ b/pkg/comments/commentsservice.go
@@ -15,7 +15,7 @@ type CommentsService struct {
 	TimeFunc func() time.Time
 }
 
-func (cs *CommentsService) PutComment(r pz.Request) pz.Response {
+func (cs *CommentsService) Put(r pz.Request) pz.Response {
 	var c types.Comment
 	if err := r.JSON(&c); err != nil {
 		return pz.BadRequest(
@@ -60,7 +60,7 @@ func (cs *CommentsService) Replies(r pz.Request) pz.Response {
 	return pz.Ok(pz.JSON(comments))
 }
 
-func (cs *CommentsService) GetComment(r pz.Request) pz.Response {
+func (cs *CommentsService) Get(r pz.Request) pz.Response {
 	comment, err := cs.Comments.Comment(
 		types.PostID(r.Vars["post-id"]),
 		types.CommentID(r.Vars["comment-id"]),
@@ -71,11 +71,34 @@ func (cs *CommentsService) GetComment(r pz.Request) pz.Response {
 	return pz.Ok(pz.JSON(comment))
 }
 
+func (cs *CommentsService) Delete(r pz.Request) pz.Response {
+	post := types.PostID(r.Vars["post-id"])
+	comment := types.CommentID(r.Vars["comment-id"])
+	if err := cs.Comments.Delete(post, comment); err != nil {
+		return pz.HandleError("deleting comment", err)
+	}
+	rsp := DeleteCommentResponse{
+		Message: "comment deleted",
+		Post:    post,
+		Comment: comment,
+		Status:  http.StatusOK,
+	}
+	return pz.Ok(pz.JSON(&rsp), &rsp)
+}
+
 type DeleteCommentResponse struct {
 	Message string          `json:"message"`
 	Post    types.PostID    `json:"post"`
 	Comment types.CommentID `json:"comment"`
 	Status  int             `json:"status"`
+}
+
+func (rsp *DeleteCommentResponse) CompareData(data []byte) error {
+	var other DeleteCommentResponse
+	if err := json.Unmarshal(data, &other); err != nil {
+		return fmt.Errorf("unmarshaling `DeleteCommentResponse`: %w", err)
+	}
+	return nil
 }
 
 func (wanted *DeleteCommentResponse) Compare(
@@ -126,25 +149,55 @@ func (wanted *DeleteCommentResponse) Compare(
 	return nil
 }
 
-func (rsp *DeleteCommentResponse) CompareData(data []byte) error {
-	var other DeleteCommentResponse
-	if err := json.Unmarshal(data, &other); err != nil {
-		return fmt.Errorf("unmarshaling `DeleteCommentResponse`: %w", err)
+func (cs *CommentsService) Update(r pz.Request) pz.Response {
+	var payload CommentUpdate
+	if err := r.JSON(&payload); err != nil {
+		return pz.BadRequest(
+			pz.JSON(&pz.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "error unmarshaling json",
+			}),
+			&struct {
+				Message string `json:"message"`
+				Error   string `json:"error"`
+			}{
+				Message: "error unmarshaling `CommentUpdate` json",
+				Error:   err.Error(),
+			},
+		)
 	}
-	return nil
+	payload.ID = types.CommentID(r.Vars["comment-id"])
+	payload.Post = types.PostID(r.Vars["post-id"])
+	if err := cs.Comments.Update(&payload); err != nil {
+		return pz.HandleError("updating comment", err)
+	}
+	return pz.Ok(pz.JSON(&UpdateResponseSuccess), &UpdateResponseSuccess)
 }
 
-func (cs *CommentsService) DeleteComment(r pz.Request) pz.Response {
-	post := types.PostID(r.Vars["post-id"])
-	comment := types.CommentID(r.Vars["comment-id"])
-	if err := cs.Comments.Delete(post, comment); err != nil {
-		return pz.HandleError("deleting comment", err)
+var (
+	UpdateResponseSuccess = &updateResponse{
+		Message: "successfully updated comment",
 	}
-	rsp := DeleteCommentResponse{
-		Message: "comment deleted",
-		Post:    post,
-		Comment: comment,
-		Status:  http.StatusOK,
+)
+
+type updateResponse struct {
+	Message string `json:"message"`
+}
+
+func (wanted *updateResponse) CompareData(data []byte) error {
+	var found updateResponse
+
+	if err := json.Unmarshal(data, &found); err != nil {
+		return fmt.Errorf("unmarshaling UpdateResponse: %w", err)
 	}
-	return pz.Ok(pz.JSON(&rsp), &rsp)
+
+	if wanted.Message != found.Message {
+		return fmt.Errorf(
+			"UpdateResponse.Message: wanted `%s`; found `%s`",
+			wanted.Message,
+			found.Message,
+		)
+	}
+
+	return nil
 }

--- a/pkg/pgcommentsstore/pgcommentsstore.go
+++ b/pkg/pgcommentsstore/pgcommentsstore.go
@@ -317,6 +317,8 @@ func fieldToSQLParam(cp *types.CommentPatch, field types.Field) interface{} {
 		return cp.Modified().Format(time.RFC3339)
 	case types.FieldDeleted:
 		return cp.Deleted()
+	case types.FieldBody:
+		return cp.Body()
 	default:
 		panic(fmt.Sprintf("invalid field: %d", field))
 	}

--- a/pkg/types/commentpatch.go
+++ b/pkg/types/commentpatch.go
@@ -217,6 +217,8 @@ func (c *Comment) marshalField(field Field) ([]byte, error) {
 		return json.Marshal(&c.Modified)
 	case FieldDeleted:
 		return json.Marshal(&c.Deleted)
+	case FieldBody:
+		return json.Marshal(&c.Body)
 	default:
 		panic(fmt.Sprintf("invalid field: %d", field))
 	}


### PR DESCRIPTION
* cmd/comments: api and webserver routes for editing/updating comments
* pkg/comments: implemented `CommentsModel.Update()`
* pkg/comments: implemented `CommentsService.Update()` route
* pkg/comments: implemented `Edit()` and `EditForm()` webserver routes
* pkg/pgcommentsstore: added missing `FieldBody` cases in `fieldToSQLParam`
* pkg/types: added missing `FieldBody` cases in `Comment.marshalField()`