### PR TITLE
standardize `pgcommentsstore` CLI to match `weberc2/auth/cmd/pgtokenstore`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/lib/pq v1.10.4
 	github.com/urfave/cli v1.22.5
+	github.com/urfave/cli/v2 v2.3.0 // indirect
 	github.com/weberc2/auth v0.0.8
 	github.com/weberc2/httpeasy v0.0.23
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/stretchr/testify v1.1.4 h1:ToftOQTytwshuOSj6bDSolVUa3GINfJP/fg3OkkOzQ
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
 github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/weberc2/auth v0.0.8 h1:XjaO0IAXXw+KZmKoTgvJ3vIoX9S27NDmN2RuWBhR5pc=
 github.com/weberc2/auth v0.0.8/go.mod h1:iUeXPqws1XtxTg0TYrFMwy/J88IG/7NfigUNsuiHWA0=
 github.com/weberc2/httpeasy v0.0.22/go.mod h1:vjZmTmHJEPKRm2tITDQyIneHOAJvyk3KhFox6MvT/2Y=
@@ -55,6 +57,7 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/pkg/pgcommentsstore/pgcommentsstore.go
+++ b/pkg/pgcommentsstore/pgcommentsstore.go
@@ -95,8 +95,8 @@ func (pgcs *PGCommentsStore) ResetTable() error {
 func (pgcs *PGCommentsStore) Put(c *types.Comment) (*types.Comment, error) {
 	if _, err := pgcs.DB.Exec(
 		"INSERT INTO comments "+
-			"(id, post, parent, author, created, modified, deleted, body) VALUES"+
-			"($1, $2, $3, $4, $5, $6, $7, $8);",
+			"(id, post, parent, author, created, modified, deleted, body) "+
+			"VALUES($1, $2, $3, $4, $5, $6, $7, $8);",
 		c.ID,
 		c.Post,
 		c.Parent,
@@ -109,10 +109,7 @@ func (pgcs *PGCommentsStore) Put(c *types.Comment) (*types.Comment, error) {
 		if err, ok := err.(*pq.Error); ok && err.Code == errUniqueViolation {
 			return nil, &types.CommentExistsErr{Post: c.Post, Comment: c.ID}
 		}
-		return nil, fmt.Errorf(
-			"inserting comment into postgres: %w",
-			err,
-		)
+		return nil, fmt.Errorf("inserting comment into postgres: %w", err)
 	}
 
 	return c, nil


### PR DESCRIPTION
* cmd/pgcommentsstore: use github.com/urfave/cli/v2 instead of v1
* cmd/pgcommentsstore: put comment management commands under `comments` command
* cmd/pgcommentsstore: use `Store` alias for `pgcommentsstore.PGCommentsStore`
* cmd/pgcommentsstore: create `table clear` command
* cmd/pgcommentsstore: use `cli.TimestampFlag` for `created`/`modified` flags
* cmd/pgcommentsstore: use similar aliases for similar verbs